### PR TITLE
Fixed data_generator; added shape check asserts in TEST_datagen

### DIFF
--- a/extract_features_and_dump.py
+++ b/extract_features_and_dump.py
@@ -61,14 +61,15 @@ def data_generator(path_to_h5py="processed_features/features.h5", batch_size=2):
 		class_of_first 	= image_fnames[i].split("/")[-2]
 		start,end 		= class_ranges[class_of_first]
 		range_of_nums 	= range(0,start) + range(end+1,DATASET_SIZE)
-		selected_indices= np.random.choice(range_of_nums, size=batch_size).tolist() # missed this!
+		selected_indices= np.random.choice(range_of_nums, size=batch_size, replace=False).tolist() # missed this! select without replacement! to avoid [1,1] error
 		selected_indices= sorted(selected_indices) # unordered indexing is not supported?
 
-		print vgg_feats[selected_indices].shape, embeddings[selected_indices].shape, selected_indices
+		# print vgg_feats[selected_indices].shape, embeddings[selected_indices].shape, selected_indices
 		# ipdb.set_trace()
+		# print i, start, end, class_of_first, selected_indices
 		X[1:]   		= vgg_feats[selected_indices]
 		y[1:]			= embeddings[selected_indices]
-
+		
 		yield X,y 
 
 

--- a/testing.py
+++ b/testing.py
@@ -5,6 +5,8 @@ import h5py
 import cPickle as pickle 
 
 PATH_h5 = "processed_features/features.h5"
+IMAGE_DIM = 4096
+WORD_DIM = 50
 
 def TEST_datagen():
 	''' Testing the data_generator function in 
@@ -20,7 +22,10 @@ def TEST_datagen():
 
 	# Run module
 	for x,y in data_generator(PATH_h5, batch_size=2):
-		print 
+		print x.shape, y.shape
+		assert x.shape[0] == y.shape[0], "batch size should be same"
+		assert x.shape[1] == IMAGE_DIM
+		assert y.shape[1] == WORD_DIM
 
 if __name__=="__main__":
 	TEST_datagen()


### PR DESCRIPTION
1. Issue: data_generator not working   
   Solution: Select indices in data_generator without replacement
   so when indexing hdf5 arr with lists, we never index repeated indices e.g [1,1]
2. In testing.py, in TEST_datagen add asserts to check shape of data returned by data_generator