### PR TITLE
testing.py, def:data_generator changes from priyam_dev

### DIFF
--- a/model.py
+++ b/model.py
@@ -16,13 +16,18 @@ IMAGE_DIM = 4096
 WORD_DIM = 50
 
 def linear_transformation(a):
-    ''' Takes a 4096-dim vector and applies 
-        a linear transformation to get 500-dim vector '''
+    """ 
+    Takes a 4096-dim vector, applies linear transformation to get WORD_DIM vector.
+    """
     b = Dense(WORD_DIM, name='transform')(a)
     return b
 
-def myloss(word_vectors, image_vectors, TESTING=False):
-    """write your loss function here, e.g mse"""
+def hinge_rank_loss(word_vectors, image_vectors, TESTING=False):
+    """
+    Custom hinge loss per (image, label) example - Page4.
+    word_vectors is y_true
+    image_vectors is y_pred
+    """
     slice_first = lambda x: x[0:1 , :]
     slice_but_first = lambda x: x[1:, :]
 
@@ -77,19 +82,18 @@ def build_model(image_features, word_features=None):
     image_vector = linear_transformation(image_features)
 
     mymodel = Model(inputs=image_features, outputs=image_vector)
-    mymodel.compile(optimizer="adam", loss=myloss)
+    mymodel.compile(optimizer="adagrad", loss=hinge_rank_loss)
     return mymodel
-    
+
 def main():
 
     image_features = Input(shape=(4096,))
     model = build_model(image_features)
     print model.summary()
 
-    for epoch in range(5):
-        for raw_image_vectors, word_vectors in data_generator(batch_size = INCORRECT_BATCH):
-            loss = model.train_on_batch(raw_image_vectors, word_vectors)
-            print "loss:",loss
+    for raw_image_vectors, word_vectors in data_generator(batch_size = INCORRECT_BATCH, epochs=50):
+        loss = model.train_on_batch(raw_image_vectors, word_vectors)
+        print "loss:",loss
 
 if __name__=="__main__":
     main()

--- a/testing.py
+++ b/testing.py
@@ -42,8 +42,9 @@ def TEST_lossfun():
 	from model import myloss
 	
 	# test
-	out = K.eval(myloss(word_vectors, image_vectors))
+	out = K.eval(myloss(word_vectors, image_vectors, TESTING=True))
 	print out
 
 if __name__=="__main__":
+	TEST_datagen()
 	TEST_lossfun()

--- a/testing.py
+++ b/testing.py
@@ -22,15 +22,16 @@ def TEST_datagen():
 	from extract_features_and_dump import data_generator
 
 	# Run module
-	for x,y in data_generator(PATH_h5, batch_size=2):
+	for x,y in data_generator(PATH_h5, batch_size=2, epochs=2):
 		print x.shape, y.shape
 		assert x.shape[0] == y.shape[0], "batch size should be same"
 		assert x.shape[1] == IMAGE_DIM
 		assert y.shape[1] == WORD_DIM
 
+	print "Completed TEST_datagen"
+
 def TEST_lossfun():
 	''' Test the hinge-rank loss function in model.py '''
-
 	# data 
 	# 1 correct word , 2 wrong ones
 	image_vectors = np.random.rand(3, WORD_DIM)
@@ -39,11 +40,13 @@ def TEST_lossfun():
 	word_vectors  = K.variable(word_vectors)
 
 	# import module 
-	from model import myloss
+	from model import hinge_rank_loss
 	
 	# test
-	out = K.eval(myloss(word_vectors, image_vectors, TESTING=True))
+	out = K.eval(hinge_rank_loss(word_vectors, image_vectors, TESTING=True))
 	print out
+
+	print "Completed TEST_lossfun"
 
 if __name__=="__main__":
 	TEST_datagen()


### PR DESCRIPTION
1. Added TESTING flag for asserting `K.eval()` - should follow this pattern moving forward.
2. Moved epoch logic from `model.py: def main()` to `extract_features_and_dump.py: def data_generator()` - avoids repeatedly loading data for every epoch(WORD_MAPPING takes a while!).
3. Updated `def data_generator()` to return correct word embeddings based on `selected_indices`.

Model overfits (0 loss) by epoch 50.