### PR TITLE
retrofit extract_features_and_dump.py + clean_data.py for mscoco_search 

### DIFF
--- a/clean_data.py
+++ b/clean_data.py
@@ -42,11 +42,14 @@ for root, dirs, files in os.walk(INPUT_PATH, topdown=False):
         list_files.append(os.path.join(root, name))
 
 
-# all types of classes + make dirs for them  
-classes = os.listdir(INPUT_PATH)
-print "Classes Found: ", classes
-for c in classes:
-	os.mkdir(os.path.join(OUTPUT_PATH,c))
+### NOTE: This piece of code not used in mscoco because 
+### it does not have any classes so we do not need to make
+### any folders for different classes.
+# # all types of classes + make dirs for them  
+# classes = os.listdir(INPUT_PATH)
+# print "Classes Found: ", classes
+# for c in classes:
+# 	os.mkdir(os.path.join(OUTPUT_PATH,c))
 
 # dump as resized .png files
 print "Dumping resized (224x224) images to disk.."

--- a/extract_features_and_dump.py
+++ b/extract_features_and_dump.py
@@ -24,18 +24,6 @@ np.random.seed(123)
 IMAGE_DIM = 4096
 WORD_DIM = 300
 
-def get_class_ranges(fnames):
-	class_ranges = {} 
-
-	for idx,fname in enumerate(fnames):
-		class_name = fname.split("/")[-2]
-		if class_name not in class_ranges.keys():
-			class_ranges[class_name] = [idx,idx]
-		else:
-			class_ranges[class_name][1] = idx
-
-	return class_ranges
-
 
 def data_generator_coco(path_to_h5py="processed_features/features.h5", incorrect_batch=2):
 	''' Data generator for coco dataset ''' 


### PR DESCRIPTION
1. remove get_class_ranges fxn from extract_feats...mp.py as it is not used anywhere. 
2. removed snippet of code in clean_data that makes folders for each class in _clean folder. no longer used. 