### PR TITLE
MAJOR changes to scrape_and_save.py for MSCOCO

### DIFF
--- a/scrape_and_save.py
+++ b/scrape_and_save.py
@@ -56,6 +56,9 @@ _c = 0
 captions_list = []
 image_TO_captions = defaultdict(list)
 
+_cap_unk_words = 0
+_unk_words = []
+
 for capId, capInfo in cocoObj.anns.iteritems(): 
 	assert capId==capInfo["id"], "Something is seriously wrong with the data!!!"
 
@@ -79,7 +82,12 @@ for capId, capInfo in cocoObj.anns.iteritems():
 			else:
 				## current strategy is to skip unknown words!
 				# new_list.append("<unk>")
-				print "UNK WORD %s:"%(word), caption_text
+				print "UNK WORD %s:"%(word), with_spaces
+				_unk_words.append(word)
+				_c+=1
+		if _c>0:
+			_cap_unk_words+=1
+		_c=0
 
 		captions_list.append(" ".join(new_list))
 

--- a/scrape_and_save.py
+++ b/scrape_and_save.py
@@ -44,6 +44,7 @@ print "\nLoading word_embeddings...\n"
 emfp = h5py.File("processed_features/embeddings.h5", 'r') 
 word_embeds	= emfp["data/word_embeddings"][:,:]
 glove_index = {w[0]:word_embeds[n].tolist() for n,w in enumerate(emfp["data/word_names"][:])}
+assert WORD_DIM==len(glove_index["the"]), "--Mismatch b/w WORD_DIM and glove data--"
 
 _response = raw_input("\nParsing captions type %s at %s ...<y/n>?"%(cap_type, loc_to_raw_file))
 if _response=='n':
@@ -69,8 +70,7 @@ for capId, capInfo in cocoObj.anns.iteritems():
 			with_spaces+=" "+char
 
 	if len(with_spaces.split())>=5: # Ultimate check for including a caption.
-		caption_count+=1
-		image_TO_captions[image_count].append(caption_count)
+		image_TO_captions[capInfo["image_id"]].append(capId)
 
 		new_list = []
 		for word in with_spaces.split():

--- a/scrape_and_save.py
+++ b/scrape_and_save.py
@@ -26,13 +26,17 @@ tempF.create_group("data")
 tempF.close()
 print "\n\n\t\tDONE\n\n"
 
-file_path = sys.argv[1]
-ENV = sys.argv[2]
-
 WHITELIST = string.letters + string.digits
 WORD_DIM = 300
 
 COCO_ROOT = "/home/tejaswin.p/MSCOCO-stuff/coco"
+
+"""
+loc_to_raw_file: location to json file for cap_type
+cap_type: train/val/test
+"""
+loc_to_raw_file, cap_type = sys.argv[1], sys.argv[2]
+assert os.path.isfile(loc_to_raw_file), "--File %s not found--"%(loc_to_raw_file)
 
 # UNK_ix = glove_index["<unk>"]
 
@@ -40,13 +44,6 @@ print "\nLoading word_embeddings...\n"
 emfp = h5py.File("processed_features/embeddings.h5", 'r') 
 word_embeds	= emfp["data/word_embeddings"][:,:]
 glove_index = {w[0]:word_embeds[n].tolist() for n,w in enumerate(emfp["data/word_names"][:])}
-
-
-loc_to_raw_file, cap_type = sys.argv[1], sys.argv[2]
-"""
-loc_to_raw_file: location to json file for cap_type
-cap_type: train/val/test
-"""
 
 _response = raw_input("\nParsing captions type %s at %s ...<y/n>?"%(cap_type, loc_to_raw_file))
 if _response=='n':

--- a/scrape_and_save.py
+++ b/scrape_and_save.py
@@ -1,7 +1,6 @@
 """
-Code to scrape images from UIUC and parse the captions.
-Creates two folders: _data & _validation.
-Validation contains every nth image and mth caption from the main set.
+Code to collect and parse captions for MSCOCO.
+Images/captions are already separated into two sets for TRAIN and VAL.
 """
 
 import os
@@ -16,6 +15,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import shutil
 import urllib
+from pycocotools.coco import COCO
 
 print "\n\n\t\tCreating features.h5 and validation_features.h5 in processed_features\n\n"
 tempF = h5py.File("processed_features/features.h5", "w")
@@ -29,137 +29,72 @@ print "\n\n\t\tDONE\n\n"
 file_path = sys.argv[1]
 ENV = sys.argv[2]
 
-image_re = re.compile('<td><img src="(.*)\/(.*)"><\/td>')
-caption_re = re.compile('<tr><td>(.*)<\/td><\/tr>')
-
-UIUC_ROOT = "UIUC_PASCAL_DATA"
-UIUC_VAL = "UIUC_PASCAL_VAL"
-UIUC_URL = "http://vision.cs.uiuc.edu/pascal-sentences"
 WHITELIST = string.letters + string.digits
 WORD_DIM = 300
 
-answer = raw_input("DO you want to continue with downloading UIUC_PASCAL stuff?<y/n>")
-if answer == "n":
-	sys.exit(0)
+COCO_ROOT = "/home/tejaswin.p/MSCOCO-stuff/coco"
 
 # UNK_ix = glove_index["<unk>"]
-
-if os.path.exists(UIUC_ROOT):
-	raw_input("\nUIUC_PASCAL_DATA detected. The program has stopped here. Press ENTER to continue downloading all data. Press CTRL+C to exit program now.\n")
-else:
-	os.makedirs(UIUC_ROOT)
-if os.path.exists(UIUC_VAL):
-	raw_input("\nUIUC_PASCAL_VAL detected. The program has stopped here. Press ENTER to continue downloading all data. Press CTRL+C to exit program now.\n")
-else:
-	os.makedirs(UIUC_VAL)
 
 print "\nLoading word_embeddings...\n"
 emfp = h5py.File("processed_features/embeddings.h5", 'r') 
 word_embeds	= emfp["data/word_embeddings"][:,:]
 glove_index = {w[0]:word_embeds[n].tolist() for n,w in enumerate(emfp["data/word_names"][:])}
 
-print "\nParsing and downloading html source...\n"
+
+loc_to_raw_file, cap_type = sys.argv[1], sys.argv[2]
+"""
+loc_to_raw_file: location to json file for cap_type
+cap_type: train/val/test
+"""
+
+_response = raw_input("\nParsing captions type %s at %s ...<y/n>?"%(cap_type, loc_to_raw_file))
+if _response=='n':
+	sys.exit()
+
+cocoObj = COCO(os.path.join(COCO_ROOT, loc_to_raw_file))
 
 _c = 0
 captions_list = []
-id_TO_class = {}
-class_TO_images = defaultdict(list)
 image_TO_captions = defaultdict(list)
 
-image_count = -1
-caption_count = -1
-uniq_class = set()
+for capId, capInfo in cocoObj.anns.iteritems(): 
+	assert capId==capInfo["id"], "Something is seriously wrong with the data!!!"
 
-with open(file_path, 'r') as fp:
-	for line in fp.readlines():
-		clean = line.strip()
+	caption_text = capInfo["caption"].strip().lower()
 
-		match_image = image_re.search(clean)
-		if match_image:
-			image_count+=1
+	tokens = []
+	with_spaces = ""
+	for char in caption_text:
+		if char in WHITELIST:
+			with_spaces+=char
+		else:
+			with_spaces+=" "+char
 
-			class_name = match_image.group(1)
-			class_name_orig = class_name
-			## Some hardcoding here.
-			if class_name=="diningtable":
-				class_name = "table"
-			if class_name=="pottedplant":
-				class_name = "plant"
-			if class_name=="tvmonitor":
-				class_name = "tv"
+	if len(with_spaces.split())>=5: # Ultimate check for including a caption.
+		caption_count+=1
+		image_TO_captions[image_count].append(caption_count)
 
-			image_name = match_image.group(2)
+		new_list = []
+		for word in with_spaces.split():
+			if word in glove_index:
+				new_list.append(word)
+			else:
+				## current strategy is to skip unknown words!
+				# new_list.append("<unk>")
+				print "UNK WORD %s:"%(word), caption_text
 
-			uniq_class.add(class_name)
+		captions_list.append(" ".join(new_list))
 
-			dir_name = os.path.join(UIUC_ROOT, class_name)
-			if not os.path.exists(dir_name):
-				os.makedirs(dir_name)
+	else:
+		print "LEN <5:", caption_text
 
-			img_name = os.path.join(dir_name, image_name)
-			img_url = os.path.join(UIUC_URL, class_name_orig, image_name)
-			system_string = "wget %s -O %s"%(img_url, img_name)
-
-			if not os.path.exists(img_name):
-				#os.system(system_string)
-                                print "Downloading link %s"%(img_url)
-				urllib.urlretrieve(img_url, img_name)
-
-			id_TO_class[len(uniq_class) -1] = class_name
-			class_TO_images[len(uniq_class) -1].append(image_count)
-			
-			continue
-
-		match_caption = caption_re.search(clean)
-		if match_caption:
-			_c+=1 # tracking number of captions which have been covered
-
-			caption_text = match_caption.group(1).strip().lower()
-
-			tokens = []
-			with_spaces = ""
-			for char in caption_text:
-				if char in WHITELIST:
-					with_spaces+=char
-				else:
-					with_spaces+=" "+char
-
-			if with_spaces[-1] in ".!":
-				with_spaces = with_spaces[:-1]
-
-			if len(with_spaces.split())>=5: # Ultimate check for including a caption.
-				caption_count+=1
-				image_TO_captions[image_count].append(caption_count)
-
-				new_list = []
-				for word in with_spaces.split():
-					if word in glove_index:
-						new_list.append(word)
-					else:
-						## current strategy is to skip unknown words!
-						# new_list.append("<unk>")
-						pass
-
-				captions_list.append(" ".join(new_list))
-
-				print caption_text
-
-		print image_count, caption_count
-		if ENV != "PROD":
-			if (_c%(3*50*5)==0) and (image_count>0):
-				print "Downloaded and processed %d images, %d captions"%(image_count+1, caption_count+1) 
-				_response = raw_input("Download more?<y/n>:")
-				if _response=="n":
-					break
-
-print "\nFinished downloading all images. Proceed with saving processed text data and meta-data?\nCtrl-C to exit.\n"
-raw_input()
+_response = raw_input("\nFinished parsing %s. Proceed with saving processed text data and meta-data?<y/n>"%(loc_to_raw_file))
+if _response=='n':
+	sys.exit()
 
 _counts = [len(c.strip().split()) for c in captions_list]
-print Counter(_counts)
-
-# plt.hist(_counts, 50)
-# plt.show()
+print sorted(Counter(_counts))
 
 from keras.preprocessing.text import Tokenizer
 from keras.preprocessing.sequence import pad_sequences
@@ -172,13 +107,7 @@ word_index = tokenizer.word_index
 print('\nFound %s unique tokens.' % len(word_index))
 data = pad_sequences(sequences, maxlen=20, padding='post', truncating='post')
 
-# missing_indices = [v for k,v in word_index.items() if k not in glove_index]
-# for ix in missing_indices:
-	# data[data==ix] = UNK_ix
-# print "Missing indices:", missing_indices
-# print "Replaced missing with <unk>"
-
-print "\nCreating embedding_layer weights..."
+print "\nCreating embedding_layer weights for type %s..."%(cap_type)
 embedding_layer = np.zeros((len(word_index) + 1, WORD_DIM))
 for word,ix in word_index.items():
 		embedding_layer[ix, :] = glove_index[word]

--- a/scrape_and_save.py
+++ b/scrape_and_save.py
@@ -70,11 +70,9 @@ for capId, capInfo in cocoObj.anns.iteritems():
 		if char in WHITELIST:
 			with_spaces+=char
 		else:
-			with_spaces+=" "+char
+			with_spaces+=" "
 
 	if len(with_spaces.split())>=5: # Ultimate check for including a caption.
-		image_TO_captions[capInfo["image_id"]].append(capId)
-
 		new_list = []
 		for word in with_spaces.split():
 			if word in glove_index:
@@ -87,12 +85,21 @@ for capId, capInfo in cocoObj.anns.iteritems():
 				_c+=1
 		if _c>0:
 			_cap_unk_words+=1
+		else:
+			## Only associate with the image if NO unk WORDS found.
+			image_TO_captions[capInfo["image_id"]].append(capId)
+			captions_list.append(" ".join(new_list).encode("utf-8"))
 		_c=0
-
-		captions_list.append(" ".join(new_list))
 
 	else:
 		print "LEN <5:", caption_text
+
+print "Unk words", _unk_words
+print "Len unkown words", len(_unk_words), len(set(_unk_words))
+print "Captions with unk words", _cap_unk_words
+
+
+#ipdb.set_trace()
 
 _response = raw_input("\nFinished parsing %s. Proceed with saving processed text data and meta-data?<y/n>"%(loc_to_raw_file))
 if _response=='n':
@@ -103,6 +110,8 @@ print sorted(Counter(_counts))
 
 from keras.preprocessing.text import Tokenizer
 from keras.preprocessing.sequence import pad_sequences
+
+#ipdb.set_trace()
 
 tokenizer = Tokenizer()
 tokenizer.fit_on_texts(captions_list)
@@ -126,11 +135,8 @@ print "\t\tword index DOES NOT CONTAIN <pad>. The index starts from 0. Size:", l
 pickle.dump(word_index, open("DICT_word_index.pkl", "w"))
 
 print "\t\tcaption_data contains ALL the captions."
-print "Use id_TO_class, class_TO_images, image_TO_captions for collecting the paired captions."
 pickle.dump(data, open("ARRAY_caption_data.pkl", "w"))
 
-pickle.dump(id_TO_class, open("DICT_id_TO_class.pkl", "w"))
-pickle.dump(class_TO_images, open("DICT_class_TO_images.pkl", "w"))
 pickle.dump(image_TO_captions, open("DICT_image_TO_captions.pkl", "w"))
 
-print "\nDONE\nRemember that the class_TO_images dict has to be udpated after shuffling validation data."
+print "\nDONE.\n"


### PR DESCRIPTION
- Accepts path to annotation file and type(TRAIN/VAL/TEST) as input: `loc_to_raw_file, cap_type`
- Skips all captions with ANY unknown words.
- Creates `word_index, caption_data, image_TO_captions` objects and saves as pkls